### PR TITLE
Update jshint option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -35,7 +35,7 @@
   "latedef": true,
 
   // Enforce line length to 80 characters
-  "maxlen": 80,
+  "maxlen": 100,
 
   // Require capitalized names for constructor functions.
   "newcap": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,6 @@ module.exports = function(grunt) {
   grunt.initConfig({
     // Metadata.
     pkg: grunt.file.readJSON('package.json'),
-    jshintrc: grunt.file.read('.jshintrc'),
     banner: '/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %> - ' +
       '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
       '<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
@@ -35,7 +34,10 @@ module.exports = function(grunt) {
       }
     },
     jshint: {
-      options: '<%= jshintrc %>',
+      options: {
+        jshintrc: '<%= baseDir %>.jshintrc',
+        reporterOutput: '',
+      },
       gruntfile: {
         src: 'Gruntfile.js'
       },


### PR DESCRIPTION
The `reporterOutput` fixes:

```
Done, but with warnings.
Running "jshint:gruntfile" (jshint) task
Warning: Path must be a string. Received null
```
