### PR TITLE
update grunt-contrib-jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-jasmine": "^0.9.2",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-istanbul": "^0.6.1",


### PR DESCRIPTION
Fixes jshint warnings that were blocking compilation.
