### PR TITLE
Added missing event-emitter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
+    "event-emitter": "^0.3.4",
     "openseadragon": "^2.1.0"
   },
   "scripts": {


### PR DESCRIPTION
This pull request adds `event-emitter` back into `package.json` as a required dependency. The current source can't seem to build without it.